### PR TITLE
Add configuration tip for Terraform

### DIFF
--- a/tips.md
+++ b/tips.md
@@ -143,6 +143,21 @@ args = '--vroot=D:\ProgramData\Compiler\v --timeout=10 --debug'
 auto_start_server = false
 ```
 
+## Terraform/HCL
+### Installation
+Use the binary from https://releases.hashicorp.com/terraform-ls/
+
+### Notes
+Terraform/HCL isn't an officially supported language, so you need to add it as a user defined language with name 'terraform'. One example how to do that could be found on [Notepad++ forum](https://community.notepad-plus-plus.org/topic/20295/terraform-hcl-syntax-highlighting-support/14).
+
+### Configuration
+```toml
+[lspservers.terraform]
+mode = "io"
+executable = 'C:\WHATEVER_PATH\terraform-ls.exe'
+args = 'serve'
+auto_start_server = false
+```
 
 *If you are using another language server and want to tell the community how to configure it, \
 I would ask you to either open an issue with the tag "Tips & Tricks" and explain it there or, \

--- a/tips.md
+++ b/tips.md
@@ -148,7 +148,10 @@ auto_start_server = false
 Use the binary from https://releases.hashicorp.com/terraform-ls/
 
 ### Notes
+
 Terraform/HCL isn't an officially supported language, so you need to add it as a user defined language with name 'terraform'. One example how to do that could be found on [Notepad++ forum](https://community.notepad-plus-plus.org/topic/20295/terraform-hcl-syntax-highlighting-support/14).
+
+Terraform-ls has a bug [#791](https://github.com/hashicorp/terraform-ls/issues/791) that prevents it from exiting when receiving a SIGTERM signal from NppLspClient plugin. You may need to kill server manually to avoid memory leaks.
 
 ### Configuration
 ```toml


### PR DESCRIPTION
Hashicorps provides an official terraform LSP, that could be used (after some tweaks) with NppLspClient.
Tested with [terraform-ls_0.29.3](https://releases.hashicorp.com/terraform-ls/0.29.3/), [Notepad++ v8.4.6](https://notepad-plus-plus.org/downloads/v8.4.6/) and [NppLspClient v0.0.13-alpha](https://github.com/Ekopalypse/NppLspClient/releases/tag/v0.0.13-alpha)